### PR TITLE
Refactor credentials handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,39 @@
 # Monolens
 
-A free, open-source MongoDB GUI IDE — a European alternative to "Studio 3T" and others.  
-Official homepage: [monolens.org](https://monolens.org)
+**Monolens** is a free, open-source MongoDB GUI IDE — a secure and efficient European alternative to proprietary tools like Studio 3T. It provides a modern, responsive interface for managing MongoDB databases.  
+
+Official homepage: [monolens.org](https://monolens.org)  
+
+Licensed under the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
+
+---
 
 ## Tech Stack
 
-- **Rust + Tauri** — fast, secure, and efficient system access  
-- **Vue 3 + TailwindCSS** — responsive, modern, and stable UI  
+- **Rust + Tauri** — high-performance backend with secure system-level access  
+- **Vue 3 + TailwindCSS** — modern, responsive, and maintainable frontend  
+
+
+## Features
+
+Currently supported features include:  
+
+- **Database Connections** — create, save, edit, and delete MongoDB connections  
+- **Credential Handling** — secure storage of credentials using the OS-native keyring  
+- **Extensible Architecture** — designed to easily add new features, such as data querying, visualization, and advanced operations  
+
+But there are many more to come!
+
 
 ## Development
 
-Install dependencies:
-
+1. **Install dependencies**  
 ```bash
 pnpm install
 ```
-
-Run in development mode:
-```
+2. **Make sure Rust is installed on your machine** [installation guide](https://rust-lang.org/tools/install/)
+3. **Additionally install Rust Tauri** [installation guide](https://tauri.app/start/prerequisites/)
+4. **Run in development mode**
+```bash
 pnpm tauri dev
-```
-
-Build a release:
-```
-pnpm tauri build
 ```

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -860,6 +860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
+ "openssl",
  "zeroize",
 ]
 
@@ -1224,12 +1225,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1242,6 +1252,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2193,7 +2209,9 @@ checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
  "dbus-secret-service",
+ "linux-keyutils",
  "log",
+ "openssl",
  "security-framework 2.11.1",
  "security-framework 3.6.0",
  "windows-sys 0.60.2",
@@ -2254,6 +2272,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -2272,6 +2291,16 @@ name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -2899,6 +2928,54 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5223,6 +5300,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,5 +31,4 @@ thiserror = "2.0.18"
 log = "0.4.29"
 tauri-plugin-log = "2"
 url = "2.5.8"
-keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "sync-secret-service"] }
-
+keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "vendored" ] }

--- a/src-tauri/src/connection_handler/connection_handler.rs
+++ b/src-tauri/src/connection_handler/connection_handler.rs
@@ -1,6 +1,6 @@
 use crate::{
     connector::models::connection::Connection,
-    drivers::{driver::DatabaseDriver, factory::DatabaseDriverFactory},
+    drivers::{driver::DatabaseDriver, errors::DriverError, factory::DatabaseDriverFactory},
 };
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
@@ -19,22 +19,16 @@ impl ConnectionHandler {
     pub async fn get_or_connect(
         &self,
         connection: Connection,
-    ) -> Result<Arc<Mutex<Box<dyn DatabaseDriver>>>, &'static str> {
+    ) -> Result<Arc<Mutex<Box<dyn DatabaseDriver>>>, DriverError> {
         let mut pool = self.connection_pool.lock().await;
 
         if let Some(driver) = pool.get(&connection.id) {
             return Ok(Arc::clone(driver));
         }
 
-        let mut driver = DatabaseDriverFactory::create(connection.clone())
-            .map_err(|e| format!("Failed to create driver {}", e))
-            .unwrap();
+        let mut driver = DatabaseDriverFactory::create(connection.clone())?;
 
-        driver
-            .connect()
-            .await
-            .map_err(|e| format!("Failed to connect: {}", e))
-            .unwrap();
+        driver.connect().await?;
 
         let shared_driver = Arc::from(Mutex::new(driver));
 
@@ -43,16 +37,12 @@ impl ConnectionHandler {
         return Ok(shared_driver);
     }
 
-    pub async fn disconnect(&self, connection_id: &str) -> Result<(), &str> {
+    pub async fn disconnect(&self, connection_id: &str) -> Result<(), DriverError> {
         let mut pool = self.connection_pool.lock().await;
 
         if let Some(lock) = pool.remove(connection_id) {
             let mut driver = lock.lock().await;
-            driver
-                .disconnect()
-                .await
-                .map_err(|e| format!("Failed to disconnect: {}", e))
-                .unwrap();
+            driver.disconnect().await?;
         }
 
         Ok(())

--- a/src-tauri/src/connector/commands/create_connection.rs
+++ b/src-tauri/src/connector/commands/create_connection.rs
@@ -14,5 +14,5 @@ pub async fn create_connection(
         .connection_repository
         .save(connection)
         .await
-        .map_err(|e| CommandError::new(e.to_string(), "repository"))
+        .map_err(|e| CommandError::new(e.to_string(), "repository", "Failed to create connection."))
 }

--- a/src-tauri/src/connector/commands/delete_connection.rs
+++ b/src-tauri/src/connector/commands/delete_connection.rs
@@ -9,5 +9,5 @@ pub async fn delete_connection(state: State<'_, AppState>, id: String) -> Result
         .connection_repository
         .delete(&id)
         .await
-        .map_err(|e| CommandError::new(e.to_string(), "repository"))
+        .map_err(|e| CommandError::new(e.to_string(), "repository", "Failed to delete connection."))
 }

--- a/src-tauri/src/connector/commands/error.rs
+++ b/src-tauri/src/connector/commands/error.rs
@@ -5,13 +5,19 @@ use thiserror::Error;
 pub struct CommandError {
     pub message: String,
     pub kind: String,
+    pub user_message: String,
 }
 
 impl CommandError {
-    pub fn new(message: impl Into<String>, kind: impl Into<String>) -> Self {
+    pub fn new(
+        message: impl Into<String>,
+        kind: impl Into<String>,
+        user_message: impl Into<String>,
+    ) -> Self {
         CommandError {
             message: message.into(),
             kind: kind.into(),
+            user_message: user_message.into(),
         }
     }
 }
@@ -21,6 +27,7 @@ impl From<std::io::Error> for CommandError {
         CommandError {
             message: err.to_string(),
             kind: String::from("io"),
+            user_message: String::from("Failed to read or write connection data."),
         }
     }
 }
@@ -30,6 +37,7 @@ impl From<serde_json::Error> for CommandError {
         CommandError {
             message: err.to_string(),
             kind: String::from("serialization"),
+            user_message: String::from("Connection data is corrupted."),
         }
     }
 }
@@ -39,6 +47,7 @@ impl From<tauri::Error> for CommandError {
         CommandError {
             message: err.to_string(),
             kind: String::from("tauri"),
+            user_message: String::from("An internal application error occurred."),
         }
     }
 }

--- a/src-tauri/src/connector/commands/error.rs
+++ b/src-tauri/src/connector/commands/error.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use thiserror::Error;
 
 #[derive(Debug, Serialize)]
 pub struct CommandError {
@@ -41,3 +42,31 @@ impl From<tauri::Error> for CommandError {
         }
     }
 }
+
+#[derive(Error, Debug)]
+pub enum RepositoryError {
+    #[error("Connection not found: {0}")]
+    NotFound(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("Credential error: {0}")]
+    Credential(#[from] CredentialError),
+
+    #[error("Migration error from version {from} to {to}")]
+    MigrationError { from: u32, to: u32 },
+}
+
+#[derive(Debug, Error)]
+pub enum CredentialError {
+    #[error("Keyring error: {0}")]
+    Keyring(#[from] keyring::Error),
+
+    #[error("Task join error: {0}")]
+    Join(#[from] tokio::task::JoinError),
+}
+

--- a/src-tauri/src/connector/commands/get_connection.rs
+++ b/src-tauri/src/connector/commands/get_connection.rs
@@ -13,5 +13,5 @@ pub async fn get_connection(
         .connection_repository
         .get(&id)
         .await
-        .map_err(|e| CommandError::new(e.to_string(), "repository"))
+        .map_err(|e| CommandError::new(e.to_string(), "repository", "Failed to load connection."))
 }

--- a/src-tauri/src/connector/commands/get_connections.rs
+++ b/src-tauri/src/connector/commands/get_connections.rs
@@ -10,5 +10,5 @@ pub async fn get_connections(state: State<'_, AppState>) -> Result<Vec<Connectio
         .connection_repository
         .list()
         .await
-        .map_err(|e| CommandError::new(e.to_string(), "repository"))
+        .map_err(|e| CommandError::new(e.to_string(), "repository", "Failed to load connections."))
 }

--- a/src-tauri/src/connector/commands/update_connection.rs
+++ b/src-tauri/src/connector/commands/update_connection.rs
@@ -14,5 +14,5 @@ pub async fn update_connection(
         .connection_repository
         .update(&id, &connection)
         .await
-        .map_err(|e| CommandError::new(e.to_string(), "repository"))
+        .map_err(|e| CommandError::new(e.to_string(), "repository", "Failed to update connection."))
 }

--- a/src-tauri/src/connector/repositories/connector_repository.rs
+++ b/src-tauri/src/connector/repositories/connector_repository.rs
@@ -1,22 +1,27 @@
-use std::error::Error;
+use std::any::Any;
 
 use async_trait::async_trait;
 
+use crate::connector::commands::error::RepositoryError;
 use crate::connector::models::create_connection::CreateConnection;
 use crate::connector::models::connection::Connection;
+use crate::connector::repositories::storage_wrapper::ConnectionStorage;
 
 #[async_trait]
 pub trait ConnectorRepository: Send + Sync {
-    async fn list(&self) -> Result<Vec<Connection>, Box<dyn Error + Send + Sync>>;
-    async fn get(&self, id: &str) -> Result<Connection, Box<dyn Error + Send + Sync>>;
+    fn as_any(&self) -> &dyn Any;
+    async fn list(&self) -> Result<Vec<Connection>, RepositoryError>;
+    async fn get(&self, id: &str) -> Result<Connection, RepositoryError>;
     async fn save(
         &self,
         connection: CreateConnection,
-    ) -> Result<Connection, Box<dyn Error + Send + Sync>>;
+    ) -> Result<Connection, RepositoryError>;
     async fn update(
         &self,
         id: &str,
         connection: &Connection,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
-    async fn delete(&self, id: &str) -> Result<(), Box<dyn Error + Send + Sync>>;
+    ) -> Result<(), RepositoryError>;
+    async fn delete(&self, id: &str) -> Result<(), RepositoryError>;
+    async fn load_storage(&self) -> Result<ConnectionStorage, RepositoryError>;
+    async fn write_storage(&self, storage: &ConnectionStorage) -> Result<(), RepositoryError>;
 }

--- a/src-tauri/src/connector/repositories/credentials/credential_service.rs
+++ b/src-tauri/src/connector/repositories/credentials/credential_service.rs
@@ -1,5 +1,6 @@
 use keyring::Entry;
-use std::error::Error;
+
+use crate::connector::commands::error::CredentialError;
 
 pub struct CredentialService {
     service_name: String,
@@ -16,11 +17,10 @@ impl CredentialService {
         &self,
         connection_id: &str,
         password: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    ) -> Result<(), CredentialError> {
         let service = self.service_name.clone();
-        let id = connection_id.to_string();
+        let key = self.get_key(connection_id);
         let pass = password.to_string();
-        let key = self.get_key(&id);
 
         tokio::task::spawn_blocking(move || {
             let entry = Entry::new(&service, &key)?;
@@ -35,10 +35,9 @@ impl CredentialService {
     pub async fn get_password(
         &self,
         connection_id: &str,
-    ) -> Result<String, Box<dyn Error + Send + Sync>> {
+    ) -> Result<String, CredentialError> {
         let service = self.service_name.clone();
-        let id = connection_id.to_string();
-        let key = self.get_key(&id);
+        let key = self.get_key(connection_id);
 
         let password = tokio::task::spawn_blocking(move || {
             let entry = Entry::new(&service, &key)?;
@@ -52,10 +51,9 @@ impl CredentialService {
     pub async fn delete_password(
         &self,
         connection_id: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    ) -> Result<(), CredentialError> {
         let service = self.service_name.clone();
-        let id = connection_id.to_string();
-        let key = self.get_key(&id);
+        let key = self.get_key(connection_id);
 
         tokio::task::spawn_blocking(move || {
             let entry = Entry::new(&service, &key)?;
@@ -67,6 +65,6 @@ impl CredentialService {
     }
 
     fn get_key(&self, connection_id: &str) -> String {
-        format!("connection:{}:password", connection_id)
+        format!("connection:{}:basic_password", connection_id)
     }
 }

--- a/src-tauri/src/connector/repositories/credentials/credential_service.rs
+++ b/src-tauri/src/connector/repositories/credentials/credential_service.rs
@@ -20,9 +20,9 @@ impl CredentialService {
         let service = self.service_name.clone();
         let id = connection_id.to_string();
         let pass = password.to_string();
+        let key = self.get_key(&id);
 
         tokio::task::spawn_blocking(move || {
-            let key = format!("connection:{}:password", id);    // namespace the key with the connection id to avoid conflicts
             let entry = Entry::new(&service, &key)?;
             entry.set_password(&pass)?;
             Ok::<_, keyring::Error>(())
@@ -38,9 +38,9 @@ impl CredentialService {
     ) -> Result<String, Box<dyn Error + Send + Sync>> {
         let service = self.service_name.clone();
         let id = connection_id.to_string();
+        let key = self.get_key(&id);
 
         let password = tokio::task::spawn_blocking(move || {
-            let key = format!("connection:{}:password", id);
             let entry = Entry::new(&service, &key)?;
             entry.get_password()
         })
@@ -55,14 +55,18 @@ impl CredentialService {
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         let service = self.service_name.clone();
         let id = connection_id.to_string();
+        let key = self.get_key(&id);
 
         tokio::task::spawn_blocking(move || {
-            let key = format!("connection:{}:password", id);
             let entry = Entry::new(&service, &key)?;
             entry.delete_credential()
         })
         .await??;
 
         Ok(())
+    }
+
+    fn get_key(&self, connection_id: &str) -> String {
+        format!("connection:{}:password", connection_id)
     }
 }

--- a/src-tauri/src/connector/repositories/file_repository.rs
+++ b/src-tauri/src/connector/repositories/file_repository.rs
@@ -1,17 +1,20 @@
-use std::error::Error;
+use std::any::Any;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
 use tokio::fs;
 
+use crate::connector::commands::error::RepositoryError;
 use crate::connector::models::authentication::AuthenticationKind;
 use crate::connector::models::connection::Connection;
 use crate::connector::models::create_connection::CreateConnection;
 use crate::connector::repositories::connector_repository::ConnectorRepository;
+use crate::connector::repositories::credentials::credential_service::CredentialService;
+use crate::connector::repositories::storage_wrapper::{ConnectionStorage, STORAGE_VERSION};
 
 pub struct FileRepository {
     base_path: PathBuf,
-    credential_service: crate::connector::repositories::credentials::credential_service::CredentialService,
+    pub credential_service: CredentialService,
 }
 
 impl FileRepository {
@@ -21,110 +24,74 @@ impl FileRepository {
             credential_service,
         }
     }
-
-    async fn write_all(
-        &self,
-        connections: &Vec<Connection>,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
-        if let Some(parent) = self.base_path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-
-        let json_str = serde_json::to_string_pretty(connections)?;
-        fs::write(&self.base_path, json_str).await?;
-        Ok(())
-    }
 }
 
 #[async_trait]
 impl ConnectorRepository for FileRepository {
-    async fn list(&self) -> Result<Vec<Connection>, Box<dyn Error + Send + Sync>> {
-        let exists = fs::try_exists(&self.base_path).await?;
-
-        if !exists {
-            return Ok(Vec::new());
-        }
-
-        let content_str = fs::read_to_string(&self.base_path)
-            .await
-            .unwrap_or_else(|err| {
-                log::error!("Could not read file content: {}", err);
-                String::new()
-            });
-
-        if content_str.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let connections: Vec<Connection> =
-            serde_json::from_str(&content_str).unwrap_or_else(|err| {
-                log::error!("Could not parse file content: {}", err);
-                Vec::new()
-            });
-
-        Ok(connections)
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    
+    async fn list(&self) -> Result<Vec<Connection>, RepositoryError> {
+        let storage = self.load_storage().await?;
+        Ok(storage.connections.values().cloned().collect())
     }
 
     async fn save(
         &self,
         mut connection: CreateConnection,
-    ) -> Result<Connection, Box<dyn Error + Send + Sync>> {
-        let mut list = self.list().await?;
+    ) -> Result<Connection, RepositoryError> {
+        let mut storage = self.load_storage().await?;
 
-        // we need to strip the password before writing it to the file
         let password = connection.authentication.password.take();
-
         let new_connection = Connection::from(connection);
 
         if let Some(pass) = password {
             self.credential_service
                 .set_password(&new_connection.id, &pass)
-                .await?;
+                .await
+                .map_err(|e| RepositoryError::Credential(e))?;
         }
 
-        list.push(new_connection.clone());
+        storage
+            .connections
+            .insert(new_connection.id.clone(), new_connection.clone());
 
-        self.write_all(&list).await?;
+        self.write_storage(&storage).await?;
 
-        return Ok(new_connection);
+        Ok(new_connection)
     }
 
-    async fn get(&self, id: &str) -> Result<Connection, Box<dyn Error + Send + Sync>> {
-        let mut connection = {
-            let list = self.list().await?;
-            list.into_iter()
-                .find(|p| p.id == id)
-                .ok_or_else(|| "Could not get Connection")?
-        };
+    async fn get(&self, id: &str) -> Result<Connection, RepositoryError> {
+        let storage = self.load_storage().await?;
 
-        if let AuthenticationKind::BASIC = connection.authentication.kind {
-            if let Ok(password) = self.credential_service.get_password(id).await {
-                connection.authentication.password = Some(password);
-            }
-        }
-
-        Ok(connection)
+        storage
+            .connections
+            .get(id)
+            .cloned()
+            .ok_or_else(|| RepositoryError::NotFound(id.to_string()))
     }
 
     async fn update(
         &self,
         id: &str,
         connection: &Connection,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    ) -> Result<(), RepositoryError> {
 
-        let mut list = self.list().await?;
+        let mut storage = self.load_storage().await?;
 
-        let item = list
-            .iter_mut()
-            .find(|p| p.id == id)
-            .ok_or_else(|| format!("Connection with id '{}' not found", id))?;
+        let existing = storage
+            .connections
+            .get_mut(id)
+            .ok_or_else(|| RepositoryError::NotFound(id.to_string()))?;
 
         match connection.authentication.kind {
             AuthenticationKind::BASIC => {
-                if let Some(password) = connection.authentication.password.clone() {
+                if let Some(password) = &connection.authentication.password {
                     self.credential_service
-                        .set_password(id, &password)
-                        .await?;
+                        .set_password(id, password)
+                        .await
+                        .map_err(|e| RepositoryError::Credential(e))?;
                 }
             }
             AuthenticationKind::NONE => {
@@ -132,28 +99,60 @@ impl ConnectorRepository for FileRepository {
             }
         }
 
-        let mut clean_connection = connection.clone();
-        clean_connection.authentication.password = None;
+        let mut clean = connection.clone();
+        clean.authentication.password = None;
 
-        *item = clean_connection;
+        *existing = clean;
 
-        self.write_all(&list).await?;
+        self.write_storage(&storage).await?;
 
         Ok(())
     }
 
-    async fn delete(&self, id: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
-        let mut list = self.list().await?;
+    async fn delete(&self, id: &str) -> Result<(), RepositoryError> {
+        let mut storage = self.load_storage().await?;
 
-        let position = list
-            .iter()
-            .position(|p| p.id == id)
-            .ok_or_else(|| format!("Connection id {} not found", id))?;
+        if storage.connections.remove(id).is_none() {
+            return Err(RepositoryError::NotFound(id.to_string()));
+        }
 
-        list.remove(position);
-        self.credential_service.delete_password(id).await.ok();
+        let _ = self.credential_service.delete_password(id).await;
 
-        self.write_all(&list).await?;
+        self.write_storage(&storage).await?;
+
+        Ok(())
+    }
+
+    async fn load_storage(&self) -> Result<ConnectionStorage, RepositoryError> {
+        if !fs::try_exists(&self.base_path).await? {
+            return Ok(ConnectionStorage::new());
+        }
+
+        let content = fs::read_to_string(&self.base_path).await?;
+
+        if content.trim().is_empty() {
+            return Ok(ConnectionStorage::new());
+        }
+
+        let storage: ConnectionStorage = serde_json::from_str(&content)?;
+
+        if storage.version != STORAGE_VERSION {
+            return Err(RepositoryError::MigrationError {
+                from: storage.version,
+                to: STORAGE_VERSION,
+            });
+        }
+
+        Ok(storage)
+    }
+
+    async fn write_storage(&self, storage: &ConnectionStorage) -> Result<(), RepositoryError> {
+        if let Some(parent) = self.base_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+
+        let json = serde_json::to_string_pretty(storage)?;
+        fs::write(&self.base_path, json).await?;
 
         Ok(())
     }

--- a/src-tauri/src/connector/repositories/file_repository.rs
+++ b/src-tauri/src/connector/repositories/file_repository.rs
@@ -56,19 +56,11 @@ impl ConnectorRepository for FileRepository {
             return Ok(Vec::new());
         }
 
-        let mut connections: Vec<Connection> =
+        let connections: Vec<Connection> =
             serde_json::from_str(&content_str).unwrap_or_else(|err| {
                 log::error!("Could not parse file content: {}", err);
                 Vec::new()
             });
-
-        for conn in &mut connections {
-            if let AuthenticationKind::BASIC = conn.authentication.kind {
-                if let Ok(password) = self.credential_service.get_password(&conn.id).await {
-                    conn.authentication.password = Some(password);
-                }
-            }
-        }
 
         Ok(connections)
     }

--- a/src-tauri/src/connector/repositories/mod.rs
+++ b/src-tauri/src/connector/repositories/mod.rs
@@ -1,3 +1,4 @@
 pub mod connector_repository;
 pub mod file_repository;
 pub mod credentials;
+pub mod storage_wrapper;

--- a/src-tauri/src/connector/repositories/storage_wrapper.rs
+++ b/src-tauri/src/connector/repositories/storage_wrapper.rs
@@ -5,7 +5,7 @@ use crate::connector::{ models::connection::Connection};
 
 pub const STORAGE_VERSION: u32 = 1;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ConnectionStorage {
     pub version: u32,
     pub connections: HashMap<String, Connection>,

--- a/src-tauri/src/connector/repositories/storage_wrapper.rs
+++ b/src-tauri/src/connector/repositories/storage_wrapper.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
+
+use crate::connector::{ models::connection::Connection};
+
+pub const STORAGE_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+pub struct ConnectionStorage {
+    pub version: u32,
+    pub connections: HashMap<String, Connection>,
+}
+
+impl ConnectionStorage {
+    pub fn new() -> Self {
+        Self {
+            version: STORAGE_VERSION,
+            connections: HashMap::new(),
+        }
+    }
+}

--- a/src-tauri/src/database/commands/get_databases.rs
+++ b/src-tauri/src/database/commands/get_databases.rs
@@ -24,8 +24,7 @@ pub async fn get_databases(
 
     let driver_lock = connection_handler
         .get_or_connect(hydrated_connection)
-        .await
-        .map_err(|e| DriverError::ConnectionFailed(e.to_string()))?;
+        .await?;
 
     let driver = driver_lock.lock().await;
     driver.list_databases().await

--- a/src-tauri/src/database/commands/get_databases.rs
+++ b/src-tauri/src/database/commands/get_databases.rs
@@ -1,19 +1,48 @@
-use tauri::State;
-
+use crate::AppState;
 use crate::connection_handler::connection_handler::ConnectionHandler;
+use crate::connector::models::authentication::AuthenticationKind;
+use crate::connector::repositories::file_repository::FileRepository;
 use crate::connector::models::connection::Connection;
 use crate::drivers::errors::DriverError;
+use tauri::State;
 
 #[tauri::command]
 pub async fn get_databases(
     connection_handler: State<'_, ConnectionHandler>,
+    app_state: State<'_, AppState>,
     connection: Connection,
 ) -> Result<Vec<String>, DriverError> {
+    // get repository from AppState
+    let repository = &app_state.connection_repository;
+
+    // hydrate_connection_with_credentials needs a concrete type
+    let hydrated_connection = if let Some(file_repo) = repository.as_any().downcast_ref::<FileRepository>() {
+        hydrate_connection_with_credentials(file_repo, &connection).await?
+    } else {
+        return Err(DriverError::ConnectionFailed("Unsupported repository type".into()));
+    };
+
     let driver_lock = connection_handler
-        .get_or_connect(connection)
+        .get_or_connect(hydrated_connection)
         .await
         .map_err(|e| DriverError::ConnectionFailed(e.to_string()))?;
 
     let driver = driver_lock.lock().await;
     driver.list_databases().await
+}
+
+async fn hydrate_connection_with_credentials(
+    repository: &FileRepository,
+    connection: &Connection,
+) -> Result<Connection, DriverError> {
+    let mut c = connection.clone();
+    if let AuthenticationKind::BASIC = c.authentication.kind {
+        let password = repository
+            .credential_service
+            .get_password(&c.id)
+            .await
+            .map_err(|_| DriverError::ConnectionFailed("Could not fetch credentials".into()))?;
+        c.authentication.password = Some(password);
+    }
+    Ok(c)
 }

--- a/src-tauri/src/database/commands/list_collections.rs
+++ b/src-tauri/src/database/commands/list_collections.rs
@@ -12,8 +12,7 @@ pub async fn list_collections(
 ) -> Result<Vec<String>, DriverError> {
     let driver_lock = connection_handler
         .get_or_connect(connection)
-        .await
-        .map_err(|e| DriverError::ConnectionFailed(e.to_string()))?;
+        .await?;
 
     let driver = driver_lock.lock().await;
     driver.list_collections(&database_name).await

--- a/src-tauri/src/database/commands/test_connection.rs
+++ b/src-tauri/src/database/commands/test_connection.rs
@@ -5,7 +5,7 @@ use crate::{
 
 #[tauri::command]
 pub async fn test_connection(connection: Connection) -> Result<Vec<TestStage>, DriverError> {
-    let mut driver = DatabaseDriverFactory::create(connection).unwrap();
+    let mut driver = DatabaseDriverFactory::create(connection)?;
 
     driver.connect().await?;
 

--- a/src-tauri/src/drivers/errors.rs
+++ b/src-tauri/src/drivers/errors.rs
@@ -1,7 +1,8 @@
-use serde::Serialize;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use thiserror::Error;
 
-#[derive(Debug, Error, Serialize)]
+#[derive(Debug, Error)]
 pub enum DriverError {
     #[error("Failed to connect: {0}")]
     ConnectionFailed(String),
@@ -26,4 +27,101 @@ pub enum DriverError {
 
     #[error("Unknown driver type")]
     UnknownDriver,
+}
+
+impl DriverError {
+    /// Returns a human-readable message suitable for display in the frontend.
+    pub fn user_message(&self) -> String {
+        match self {
+            DriverError::ConnectionFailed(msg) => {
+                if Self::is_auth_error(msg) {
+                    String::from("Authentication failed. Check your username, password, and authentication database.")
+                } else {
+                    String::from("Failed to connect. Verify your host, port, and that the server is running.")
+                }
+            }
+            DriverError::ClientNotInitialized => {
+                String::from("Connection was not initialized. Please try again.")
+            }
+            DriverError::PingFailed(msg) => {
+                if Self::is_auth_error(msg) {
+                    String::from("Authentication failed. Check your username, password, and authentication database.")
+                } else if Self::is_timeout_error(msg) {
+                    String::from("Connection timed out. Check your host, port, and firewall settings.")
+                } else {
+                    String::from("Could not reach the database. Check your host, port, and firewall settings.")
+                }
+            }
+            DriverError::ListDatabasesFailed(msg) => {
+                if Self::is_auth_error(msg) {
+                    String::from("Authentication failed. Check your username, password, and permissions.")
+                } else {
+                    String::from("Failed to retrieve databases. Check your permissions.")
+                }
+            }
+            DriverError::ListCollectionsFailed(_, msg) => {
+                if Self::is_auth_error(msg) {
+                    String::from("Authentication failed. Check your permissions on this database.")
+                } else {
+                    String::from("Failed to list collections. Check your permissions on this database.")
+                }
+            }
+            DriverError::ServerStatusFailed(msg) => {
+                if Self::is_auth_error(msg) {
+                    String::from("Authentication failed. Check your username, password, and permissions.")
+                } else {
+                    String::from("Could not read server status. Check your permissions.")
+                }
+            }
+            DriverError::UriMalformed(_) => {
+                String::from("The connection URI is invalid. Please check the format.")
+            }
+            DriverError::UnknownDriver => String::from("Unsupported database driver."),
+        }
+    }
+
+    /// Detects if a raw driver error message indicates an authentication failure.
+    fn is_auth_error(msg: &str) -> bool {
+        let lower = msg.to_lowercase();
+        lower.contains("authentication failed")
+            || lower.contains("auth error")
+            || lower.contains("unauthorized")
+            || lower.contains("autherror")
+            || lower.contains("authentication")
+    }
+
+    /// Detects if a raw driver error message indicates a timeout.
+    fn is_timeout_error(msg: &str) -> bool {
+        let lower = msg.to_lowercase();
+        lower.contains("timed out")
+            || lower.contains("timeout")
+            || lower.contains("server selection timeout")
+    }
+
+    /// Returns the variant name as a string.
+    fn kind(&self) -> &str {
+        match self {
+            DriverError::ConnectionFailed(_) => "ConnectionFailed",
+            DriverError::ClientNotInitialized => "ClientNotInitialized",
+            DriverError::PingFailed(_) => "PingFailed",
+            DriverError::ListDatabasesFailed(_) => "ListDatabasesFailed",
+            DriverError::ListCollectionsFailed(_, _) => "ListCollectionsFailed",
+            DriverError::ServerStatusFailed(_) => "ServerStatusFailed",
+            DriverError::UriMalformed(_) => "UriMalformed",
+            DriverError::UnknownDriver => "UnknownDriver",
+        }
+    }
+}
+
+impl Serialize for DriverError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("DriverError", 3)?;
+        state.serialize_field("kind", self.kind())?;
+        state.serialize_field("message", &self.to_string())?;
+        state.serialize_field("user_message", &self.user_message())?;
+        state.end()
+    }
 }

--- a/src-tauri/src/drivers/mongo_official_driver.rs
+++ b/src-tauri/src/drivers/mongo_official_driver.rs
@@ -52,7 +52,7 @@ impl MongoDbOfficialDriver {
 
         uri.set_query(Some(query.join("&").as_str()));
 
-        log::debug!("Builded connection query: {}", uri.as_str());
+        log::debug!("Built connection query: {}", uri.as_str());
 
         Ok(uri.to_string())
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "Monolens",
-        "width": 800,
-        "height": 600
+        "width": 1200,
+        "height": 900
       }
     ],
     "security": {

--- a/src/components/connection/ConnectionDialog.vue
+++ b/src/components/connection/ConnectionDialog.vue
@@ -171,6 +171,13 @@ async function handleSave() {
 }
 
 const useAuth = computed(() => form.values.useAuth);
+const everythingFilled = computed(() => {
+  if (form.values.useAuth) {
+    return form.values.name && form.values.uri && form.values.port && form.values.username && form.values.password && form.values.authDatabase;
+  } else {
+    return form.values.name && form.values.uri && form.values.port;
+  }
+});
 </script>
 
 <template>
@@ -296,7 +303,7 @@ const useAuth = computed(() => form.values.useAuth);
         <Button 
           type="button" 
           variant="outline" 
-          :disabled="store.isTesting"
+          :disabled="store.isTesting || !everythingFilled"
           @click="handleTest"
         >
           {{ store.isTesting ? 'Testing...' : 'Test Connection' }}

--- a/src/components/connection/ConnectionDialog.vue
+++ b/src/components/connection/ConnectionDialog.vue
@@ -22,6 +22,7 @@ import {
 import Input from '@/components/ui/input/Input.vue';
 import Button from '@/components/ui/button/Button.vue';
 import TestStagesDisplay from './TestStagesDisplay.vue';
+import { Eye, EyeOff } from 'lucide-vue-next';
 
 import { useConnectionStore } from '@/stores/connectionStore';
 import { 
@@ -108,6 +109,7 @@ watch(isOpen, (open) => {
 });
 
 const testPassed = ref(false);
+const showPassword = ref(false);
 
 function buildConnectionFromForm(values: typeof form.values): Omit<Connection, 'id'> {
   return {
@@ -264,11 +266,23 @@ const everythingFilled = computed(() => {
             <FormItem>
               <FormLabel>Password</FormLabel>
               <FormControl>
-                <Input 
-                  type="password" 
-                  placeholder="Password" 
-                  v-bind="componentField" 
-                />
+                <div class="relative">
+                  <Input 
+                    :type="showPassword ? 'text' : 'password'" 
+                    placeholder="Password" 
+                    v-bind="componentField" 
+                    class="pr-10"
+                  />
+                  <button
+                    type="button"
+                    class="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    tabindex="-1"
+                    @click="showPassword = !showPassword"
+                  >
+                    <EyeOff v-if="showPassword" class="h-4 w-4" />
+                    <Eye v-else class="h-4 w-4" />
+                  </button>
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -289,11 +303,16 @@ const everythingFilled = computed(() => {
           </FormField>
         </div>
         
+        <div v-if="store.error" class="p-3 bg-destructive/10 border border-destructive/20 rounded-md">
+          <p class="text-sm text-destructive">{{ store.error }}</p>
+        </div>
+
         <div v-if="store.testStages.length > 0 || store.isTesting || store.testError" class="pt-4 border-t">
           <h4 class="text-sm font-medium mb-2">Connection Test</h4>
           <TestStagesDisplay 
             :stages="store.testStages" 
             :error="store.testError"
+            :error-detail="store.testErrorDetail"
             :is-loading="store.isTesting"
           />
         </div>

--- a/src/components/connection/TestStagesDisplay.vue
+++ b/src/components/connection/TestStagesDisplay.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-import { Check, X, Loader2 } from 'lucide-vue-next';
+import { ref } from 'vue';
+import { Check, X, Loader2, ChevronDown, ChevronRight } from 'lucide-vue-next';
 import type { TestStage } from '@/domains/connections';
 
 defineProps<{
   stages: TestStage[];
   error?: string | null;
+  errorDetail?: string | null;
   isLoading?: boolean;
 }>();
+
+const showDetail = ref(false);
 </script>
 
 <template>
@@ -29,7 +33,20 @@ defineProps<{
     </div>
 
     <div v-if="error" class="mt-3 p-3 bg-destructive/10 border border-destructive/20 rounded-md w-100 break-words">
-      <p class="text-sm text-destructive whitespace-pre-wrap">{{ error }}</p>
+      <p class="text-sm text-destructive">{{ error }}</p>
+      <button
+        v-if="errorDetail && errorDetail !== error"
+        class="mt-2 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        @click="showDetail = !showDetail"
+      >
+        <ChevronDown v-if="showDetail" class="w-3 h-3" />
+        <ChevronRight v-else class="w-3 h-3" />
+        {{ showDetail ? 'Hide details' : 'Show details' }}
+      </button>
+      <pre
+        v-if="showDetail && errorDetail"
+        class="mt-2 text-xs text-muted-foreground whitespace-pre-wrap font-mono bg-muted/50 rounded p-2"
+      >{{ errorDetail }}</pre>
     </div>
   </div>
 </template>

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -75,10 +75,16 @@ export const useConnectionStore = defineStore('connection', () => {
     isDatabasesLoading.value = true;
     
     try {
-      const dbs = await invoke<string[]>('get_databases', { connection });
-      databases.value = dbs;
-      activeConnectionId.value = connection.id;
-      return true;
+      const hydrated_connection = await hydrateConnectionWithCredentials(connection);
+
+      if (hydrated_connection) {
+        const dbs = await invoke<string[]>('get_databases', { connection: hydrated_connection });
+        databases.value = dbs;
+        activeConnectionId.value = hydrated_connection.id;
+        return true;
+      }
+
+      return false;
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e);
       return false;
@@ -111,6 +117,22 @@ export const useConnectionStore = defineStore('connection', () => {
       return [];
     } finally {
       isTesting.value = false;
+    }
+  }
+
+  async function hydrateConnectionWithCredentials(connection: Connection): Promise<Connection | null> {
+    try {
+      const result = await connectionService.getConnection(connection.id);
+      logger.debug('Fetched connection with credentials for connection id:', connection.id);
+      if (result.data) {
+        return result.data;
+      } else {
+        error.value = result.error instanceof Error ? result.error.message : String(result.error);
+        return null;
+      }
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : String(e);
+      return null;
     }
   }
 

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -64,11 +64,8 @@ export const useConnectionStore = defineStore('connection', () => {
     if (activeConnectionId.value === id) {
         activeConnectionId.value = null;
         databases.value = [];
-      return true;
-    } else {
-      error.value = `Failed to delete connection with id ${id}.`;
-      return false;
     }
+    return true;
   }
 
   async function connectTo(connection: Connection): Promise<boolean> {

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -1,6 +1,7 @@
 import { useLogger } from '@/composables/useLogger';
 import { useDomain } from '@/domains';
 import { Connection, ConnectionServiceIPC, TestStage } from '@/domains/connections';
+import { extractErrorMessage } from '@/utils/errorMessage';
 import { invoke } from '@tauri-apps/api/core';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
@@ -17,6 +18,7 @@ export const useConnectionStore = defineStore('connection', () => {
   const isTesting = ref(false);
   const testStages = ref<TestStage[]>([]);
   const testError = ref<string | null>(null);
+  const testErrorDetail = ref<string | null>(null);
 
   const isLoading = ref(false);
   const error = ref<string | null>(null);
@@ -30,7 +32,7 @@ export const useConnectionStore = defineStore('connection', () => {
     if (result.data) {
       connections.value = result.data;
     } else {
-      error.value = result.error instanceof Error ? result.error.message : String(result.error);
+      error.value = extractErrorMessage(result.error);
     }
     isLoading.value = false;
   }
@@ -41,13 +43,17 @@ export const useConnectionStore = defineStore('connection', () => {
       connections.value.push(created.data);
       return created.data;
     } else {
-      error.value = created.error instanceof Error ? created.error.message : String(created.error);
+      error.value = extractErrorMessage(created.error);
       return null;
     }
   }
 
   async function updateConnection(id: string, connection: Connection): Promise<boolean> {
-    await connectionService.updateConnection(id, connection);
+    const result = await connectionService.updateConnection(id, connection);
+    if (result.error) {
+      error.value = extractErrorMessage(result.error);
+      return false;
+    }
     const index = connections.value.findIndex(c => c.id === id);
     if (index !== -1) {
       connections.value[index] = connection;
@@ -59,7 +65,11 @@ export const useConnectionStore = defineStore('connection', () => {
   }
 
   async function deleteConnection(id: string): Promise<boolean> {
-    await connectionService.deleteConnection(id);
+    const result = await connectionService.deleteConnection(id);
+    if (result.error) {
+      error.value = extractErrorMessage(result.error);
+      return false;
+    }
     connections.value = connections.value.filter(c => c.id !== id);
     if (activeConnectionId.value === id) {
         activeConnectionId.value = null;
@@ -78,7 +88,7 @@ export const useConnectionStore = defineStore('connection', () => {
 
       return true;
     } catch (e) {
-      error.value = e instanceof Error ? e.message : String(e);
+      error.value = extractErrorMessage(e);
       return false;
     } finally {
       isDatabasesLoading.value = false;
@@ -88,6 +98,7 @@ export const useConnectionStore = defineStore('connection', () => {
   async function testConnection(connection: Omit<Connection, 'id'>): Promise<TestStage[]> {
     isTesting.value = true;
     testError.value = null;
+    testErrorDetail.value = null;
     testStages.value = [];
     
     try {
@@ -98,13 +109,9 @@ export const useConnectionStore = defineStore('connection', () => {
       return stages;
     } catch (e) {
       logger.error('test_connection error:', e);
-      if (e instanceof Error) {
-        testError.value = e.message;
-      } else if (typeof e === 'object' && e !== null) {
-        const values = Object.values(e as Record<string, unknown>);
-        testError.value = values.length > 0 ? String(values[0]) : JSON.stringify(e);
-      } else {
-        testError.value = String(e);
+      testError.value = extractErrorMessage(e);
+      if (typeof e === 'object' && e !== null && 'message' in e) {
+        testErrorDetail.value = (e as Record<string, unknown>).message as string;
       }
       return [];
     } finally {
@@ -120,6 +127,7 @@ export const useConnectionStore = defineStore('connection', () => {
   function clearTestState() {
     testStages.value = [];
     testError.value = null;
+    testErrorDetail.value = null;
     isTesting.value = false;
   }
 
@@ -142,6 +150,7 @@ export const useConnectionStore = defineStore('connection', () => {
     testStages,
     isTesting,
     testError,
+    testErrorDetail,
     databases,
     isDatabasesLoading,
   }

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -72,16 +72,11 @@ export const useConnectionStore = defineStore('connection', () => {
     isDatabasesLoading.value = true;
     
     try {
-      const hydrated_connection = await hydrateConnectionWithCredentials(connection);
+      const dbs = await invoke<string[]>('get_databases', { connection });
+      databases.value = dbs;
+      activeConnectionId.value = connection.id;
 
-      if (hydrated_connection) {
-        const dbs = await invoke<string[]>('get_databases', { connection: hydrated_connection });
-        databases.value = dbs;
-        activeConnectionId.value = hydrated_connection.id;
-        return true;
-      }
-
-      return false;
+      return true;
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e);
       return false;
@@ -114,22 +109,6 @@ export const useConnectionStore = defineStore('connection', () => {
       return [];
     } finally {
       isTesting.value = false;
-    }
-  }
-
-  async function hydrateConnectionWithCredentials(connection: Connection): Promise<Connection | null> {
-    try {
-      const result = await connectionService.getConnection(connection.id);
-      logger.debug('Fetched connection with credentials for connection id:', connection.id);
-      if (result.data) {
-        return result.data;
-      } else {
-        error.value = result.error instanceof Error ? result.error.message : String(result.error);
-        return null;
-      }
-    } catch (e) {
-      error.value = e instanceof Error ? e.message : String(e);
-      return null;
     }
   }
 

--- a/src/utils/errorMessage.ts
+++ b/src/utils/errorMessage.ts
@@ -1,0 +1,50 @@
+/**
+ * A backend error object coming from Tauri commands.
+ * Both DriverError and CommandError serialize with these fields.
+ */
+interface BackendError {
+  user_message?: string;
+  message?: string;
+  kind?: string;
+}
+
+function isBackendError(e: unknown): e is BackendError {
+  return typeof e === 'object' && e !== null && ('user_message' in e || 'message' in e);
+}
+
+/**
+ * Extracts a human-readable error message from any error shape returned by the backend.
+ *
+ * Priority:
+ *  1. `user_message` field (set by DriverError / CommandError in the backend)
+ *  2. `message` field (raw technical detail — fallback)
+ *  3. Error.message (standard JS Error)
+ *  4. Generic fallback string
+ */
+export function extractErrorMessage(e: unknown): string {
+  if (isBackendError(e)) {
+    if (e.user_message) return e.user_message;
+    if (e.message) return e.message;
+  }
+
+  if (e instanceof Error) {
+    return e.message;
+  }
+
+  if (typeof e === 'string') {
+    return e;
+  }
+
+  return 'An unexpected error occurred.';
+}
+
+/**
+ * Extracts the raw technical detail from a backend error, if available.
+ * Useful for a "Show details" toggle in the UI.
+ */
+export function extractErrorDetail(e: unknown): string | null {
+  if (isBackendError(e) && e.message) {
+    return e.message;
+  }
+  return null;
+}


### PR DESCRIPTION
Credentials are now never exposed to the frontend.
Everything that needs credentials runs directly in rust without the frontend touching them.
Enabled better error handling and error responses.
Credentials are now stored in the OS native keychain (Mac, Windows, Linux).